### PR TITLE
Use round() for `julian_day_to_unix_millis` and `julian_day_to_unixtime`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 /// Public constant that may be useful to library users
 /// 1970-01-01 00:00:00 UTC
-pub const JULIAN_DAY_UNIX_EPOCH_DAYS: f64 = 2440587.5; 
+pub const JULIAN_DAY_UNIX_EPOCH_DAYS: f64 = 2440587.5;
 
 /// The weekday index for the Unix Epoch (1970-01-01 UTC) is Thursday (4)
 pub const JULIAN_DAY_UNIX_EPOCH_WEEKDAY: u8 = 4;
@@ -25,7 +25,10 @@ pub struct DateRangeConversionError;
 
 impl fmt::Display for DateRangeConversionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "DateRangeConversionError: The provided Julian Day is out of the supported range.")
+        write!(
+            f,
+            "DateRangeConversionError: The provided Julian Day is out of the supported range."
+        )
     }
 }
 
@@ -41,7 +44,6 @@ pub fn unix_millis_to_julian_day(ms: i64) -> f64 {
     (ms as f64 / 86_400_000.0) + JULIAN_DAY_UNIX_EPOCH_DAYS
 }
 
-
 /// Convert a Unix timestamp seconds as a 64-bit integer to Julian days as a 64-bit float
 ///
 /// ## Example:
@@ -51,7 +53,7 @@ pub fn unix_millis_to_julian_day(ms: i64) -> f64 {
 /// let julian_day: f64 = unixtime_to_julian_day(1_672_929_282);
 /// ```
 pub fn unixtime_to_julian_day(ms: i64) -> f64 {
-  (ms as f64 / 86_400.0) + JULIAN_DAY_UNIX_EPOCH_DAYS
+    (ms as f64 / 86_400.0) + JULIAN_DAY_UNIX_EPOCH_DAYS
 }
 
 /// Convert Julian day as a 64-bit float to Unix timestamp milliseconds as a signed 64-bit integer
@@ -77,7 +79,7 @@ pub fn julian_day_to_unix_millis(jd: f64) -> i64 {
 /// let unix_seconds: i64 = julian_day_to_unixtime(julian_day);
 /// ```
 pub fn julian_day_to_unixtime(jd: f64) -> i64 {
-  ((jd - JULIAN_DAY_UNIX_EPOCH_DAYS) * 86_400.0).round() as i64
+    ((jd - JULIAN_DAY_UNIX_EPOCH_DAYS) * 86_400.0).round() as i64
 }
 
 /// Convert Julian day as a 64-bit float to a timezone-neutral chrono::NaiveDateTime object
@@ -93,7 +95,7 @@ pub fn julian_day_to_unixtime(jd: f64) -> i64 {
 /// }
 /// ```
 pub fn julian_day_to_datetime(jd: f64) -> Result<NaiveDateTime, DateRangeConversionError> {
-    if jd >= JULIAN_DAY_MIN_SUPPORTED && jd <= JULIAN_DAY_MAX_SUPPORTED {
+    if (JULIAN_DAY_MIN_SUPPORTED..=JULIAN_DAY_MAX_SUPPORTED).contains(&jd) {
         let milliseconds = julian_day_to_unix_millis(jd);
         if let Some(dt) = DateTime::from_timestamp_millis(milliseconds) {
             return Ok(dt.naive_utc());
@@ -109,7 +111,9 @@ pub trait JulianDay {
     fn to_jd(&self) -> f64;
 
     /// Convert from a Julian Day as f64 to DateTime Object
-    fn from_jd(jd: f64) -> Option<Self> where Self: Sized;
+    fn from_jd(jd: f64) -> Option<Self>
+    where
+        Self: Sized;
 }
 
 impl JulianDay for NaiveDateTime {
@@ -185,5 +189,9 @@ pub fn julian_day_to_weekday_index(jd: f64, offset_secs: i32) -> u8 {
 /// as used in Java, C# and ISO 8601 (Python's datetime.weekday() method is 0-based from Monday)
 pub fn julian_day_to_weekday_number(jd: f64, offset_secs: i32) -> u8 {
     let index = julian_day_to_weekday_index(jd, offset_secs);
-    if index == 0 { 7 } else { index }
+    if index == 0 {
+        7
+    } else {
+        index
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub fn unixtime_to_julian_day(ms: i64) -> f64 {
 /// let unix_millis: i64 = julian_day_to_unix_millis(julian_day);
 /// ```
 pub fn julian_day_to_unix_millis(jd: f64) -> i64 {
-    ((jd - JULIAN_DAY_UNIX_EPOCH_DAYS) * 86_400_000.0) as i64
+    ((jd - JULIAN_DAY_UNIX_EPOCH_DAYS) * 86_400_000.0).round() as i64
 }
 
 /// Convert Julian day as a 64-bit float to Unix timestamp seconds as a signed 64-bit integer
@@ -77,7 +77,7 @@ pub fn julian_day_to_unix_millis(jd: f64) -> i64 {
 /// let unix_seconds: i64 = julian_day_to_unixtime(julian_day);
 /// ```
 pub fn julian_day_to_unixtime(jd: f64) -> i64 {
-  ((jd - JULIAN_DAY_UNIX_EPOCH_DAYS) * 86_400.0) as i64
+  ((jd - JULIAN_DAY_UNIX_EPOCH_DAYS) * 86_400.0).round() as i64
 }
 
 /// Convert Julian day as a 64-bit float to a timezone-neutral chrono::NaiveDateTime object

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -52,6 +52,11 @@ fn test_unixtime_conversion() {
     let expected_unixtime: i64 = 1662314400;
     let result: i64 = julian_day_to_unixtime(julian_day);
     assert_eq!(expected_unixtime, result);
+
+    let julian_day: f64 = 2459717.08070103;
+    let expected_unixtime: i64 = 1652795773;
+    let result: i64 = julian_day_to_unixtime(julian_day);
+    assert_eq!(expected_unixtime, result);
 }
 
 #[test]
@@ -61,6 +66,11 @@ fn test_julian_day_datetime_utc() {
     let expected_datetime_string = "2023-09-06T09:00:00".to_string();
     let result = datetime.format("%Y-%m-%dT%H:%M:%S").to_string();
     assert_eq!(expected_datetime_string, result);
+
+    let datetime = julian_day_to_datetime(2459717.08070103).ok().unwrap();
+    let expected_datetime_string = "2022-05-17T13:56:12.569".to_string();
+    let result = datetime.format("%Y-%m-%dT%H:%M:%S%.f");
+    assert_eq!(expected_datetime_string, result.to_string());
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,25 +1,30 @@
 use std::str::FromStr;
 
-use julian_day_converter::*;
 use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
+use julian_day_converter::*;
 
 #[cfg(test)]
-
 #[test]
 fn test_basic_date() {
     // Test conversion from Julian Day to NaiveDateTime and formatting
     let julian_day = 2459827.25;
     let expected_datetime_utc = "2022-09-04T18:00:00";
     let result = NaiveDateTime::from_jd(julian_day);
-    let incorrect_datetime = NaiveDateTime::new(NaiveDate::from_ymd_opt(1970,1, 1).unwrap(),NaiveTime::from_hms_opt(0,0,0).unwrap());
-    let formatted_datetime = result.unwrap_or(incorrect_datetime).format("%Y-%m-%dT%H:%M:%S").to_string();
+    let incorrect_datetime = NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
+        NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+    );
+    let formatted_datetime = result
+        .unwrap_or(incorrect_datetime)
+        .format("%Y-%m-%dT%H:%M:%S")
+        .to_string();
     assert_eq!(formatted_datetime, expected_datetime_utc.to_string());
 
     // Test conversion from NaiveDateTime to Julian Day
     let historical_datetime = "1876-09-25T12:00:00";
     let date_time = NaiveDateTime::from_str(historical_datetime).unwrap();
     let jd = date_time.to_jd();
-    assert_eq!(jd,  2406523.0);
+    assert_eq!(jd, 2406523.0);
 }
 
 #[test]
@@ -37,12 +42,25 @@ fn test_first_julian_day() {
     let julian_day = 0f64;
     let expected_datetime_utc = "-4713-11-24T12:00:00"; // BCE
     let result = NaiveDateTime::from_jd(julian_day);
-    let incorrect_datetime = NaiveDateTime::new(NaiveDate::from_ymd_opt(1970,1, 1).unwrap(),NaiveTime::from_hms_opt(0,0,0).unwrap());
-    let formatted_datetime = result.unwrap_or(incorrect_datetime).format("%Y-%m-%dT%H:%M:%S").to_string();
+    let incorrect_datetime = NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
+        NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+    );
+    let formatted_datetime = result
+        .unwrap_or(incorrect_datetime)
+        .format("%Y-%m-%dT%H:%M:%S")
+        .to_string();
     assert_eq!(formatted_datetime, expected_datetime_utc.to_string());
-  
+
     let ancient_jd: f64 = 0.0;
-    assert_eq!(julian_day_to_datetime(ancient_jd).ok().unwrap().format("%Y-%m-%dT%H:%M:%S").to_string(), "-4713-11-24T12:00:00".to_string());
+    assert_eq!(
+        julian_day_to_datetime(ancient_jd)
+            .ok()
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string(),
+        "-4713-11-24T12:00:00".to_string()
+    );
 }
 
 #[test]
@@ -76,14 +94,31 @@ fn test_julian_day_datetime_utc() {
 #[test]
 fn test_julian_day_range() {
     // Test conversion of minimum and maximum supported Julian Days to NaiveDateTime
-    assert_eq!(julian_day_to_datetime(JULIAN_DAY_MIN_SUPPORTED).ok().unwrap().format("%Y-%m-%dT%H:%M:%S").to_string(), "-9999-01-01T00:00:00".to_string());
-    assert_eq!(julian_day_to_datetime(JULIAN_DAY_MAX_SUPPORTED).ok().unwrap().format("%Y-%m-%dT%H:%M:%S").to_string(), "9999-12-31T23:59:59".to_string());
+    assert_eq!(
+        julian_day_to_datetime(JULIAN_DAY_MIN_SUPPORTED)
+            .ok()
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string(),
+        "-9999-01-01T00:00:00".to_string()
+    );
+    assert_eq!(
+        julian_day_to_datetime(JULIAN_DAY_MAX_SUPPORTED)
+            .ok()
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string(),
+        "9999-12-31T23:59:59".to_string()
+    );
 }
 
 #[test]
 fn test_weekday_index() {
     // Test calculation of weekday index with different timezone offsets
-    let incorrect_datetime = NaiveDateTime::new(NaiveDate::from_ymd_opt(1970,1, 1).unwrap(),NaiveTime::from_hms_opt(0,0,0).unwrap());
+    let incorrect_datetime = NaiveDateTime::new(
+        NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
+        NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+    );
     let expected_weekday_index = 0; // Sunday = 0
     let datetime_utc = "2022-09-04T18:00:00"; // Sunday
     let dt = NaiveDateTime::from_str(str::trim(&datetime_utc)).unwrap_or(incorrect_datetime);
@@ -96,7 +131,10 @@ fn test_weekday_index() {
     let iso_weekday_number = 7; // Sunday = 7 with UTC offset
     assert_eq!(dt.weekday_number(0), iso_weekday_number);
 
-    assert_eq!(dt.weekday_index(0), dt.format("%w").to_string().parse::<u8>().unwrap());
+    assert_eq!(
+        dt.weekday_index(0),
+        dt.format("%w").to_string().parse::<u8>().unwrap()
+    );
 }
 
 #[test]
@@ -107,7 +145,7 @@ fn test_year_range_with_i64_timestamps() {
 
     let julian_i64_max = unix_millis_to_julian_day(max_i64);
     let max_years = julian_i64_max / 365.25;
-    
+
     let julian_i64_min = unix_millis_to_julian_day(min_i64);
     let min_years = julian_i64_min / 365.25;
 
@@ -123,12 +161,23 @@ fn test_milliseconds() {
 
     // Format with milliseconds and Z timezone suffix compatible with JavaScript Date object constructors
     // to ensure the UTC datetime string is not offset by local time
-    let formatted_datetime_string = NaiveDateTime::from_jd(jd).unwrap().format(iso_8601with_millis_and_tz_format).to_string();
+    let formatted_datetime_string = NaiveDateTime::from_jd(jd)
+        .unwrap()
+        .format(iso_8601with_millis_and_tz_format)
+        .to_string();
 
     // Extract a slice of the last five characters e.g. ".275Z"
     // and compare character by character
-    let last_five_chars = &formatted_datetime_string[formatted_datetime_string.len()-5..].chars().collect::<Vec<char>>();
-    assert!(last_five_chars[0] == '.' && last_five_chars[1].is_digit(10) && last_five_chars[2].is_digit(10) && last_five_chars[3].is_digit(10) && last_five_chars[4] == 'Z');
+    let last_five_chars = &formatted_datetime_string[formatted_datetime_string.len() - 5..]
+        .chars()
+        .collect::<Vec<char>>();
+    assert!(
+        last_five_chars[0] == '.'
+            && last_five_chars[1].is_digit(10)
+            && last_five_chars[2].is_digit(10)
+            && last_five_chars[3].is_digit(10)
+            && last_five_chars[4] == 'Z'
+    );
 
     // Check that the milliseconds are not all zeros
     let millis_slice = last_five_chars[1..4].iter().collect::<String>();


### PR DESCRIPTION
The current implementation has an issue:
```
    let d1 = NaiveDateTime::parse_from_str("2022-05-17 13:56:12.569", "%Y-%m-%d %H:%M:%S%.f").unwrap();
    dbg!(&d1.to_jd());   // &d1.to_jd() = 2459717.08070103
    let d2 = julian_day_converter::julian_day_to_datetime(2459717.08070103).unwrap();
    dbg!(&d2);   //&d2 = 2022-05-17T13:56:12.568;  we lost one milliseconds here
```
This is because when converting `julian_day` to `unix_millis`, we truncate the `f64` by default.

This PR contains two commits(please review them separately):

1. Address the precision issue
2. Resolve code formatting and `cargo clippy` warning